### PR TITLE
Evaluate results immediately after run

### DIFF
--- a/evaluation/main_evaluation.py
+++ b/evaluation/main_evaluation.py
@@ -15,12 +15,8 @@ def run(args):
     # Create dataset evaluator: runs vio depending on given params and analyzes output.
     extra_flagfile_path = ""  # TODO(marcus): parse from experiments
     # TODO(marcus): choose which of the following based on -r -a flags
-    if args.run_pipeline:
-        dataset_runner = DatasetRunner(experiment_params, args, extra_flagfile_path)
-        dataset_runner.run_all()
-    if args.analyze_vio:
-        dataset_evaluator = DatasetEvaluator(experiment_params, args)
-        dataset_evaluator.evaluate_all()
+    dataset_evaluator = DatasetEvaluator(experiment_params, args, extra_flagfile_path)
+    dataset_evaluator.evaluate()
     # Aggregate results in results directory
     aggregate_ape_results(os.path.expandvars(experiment_params['results_dir']))
     return True
@@ -67,9 +63,9 @@ if __name__ == '__main__':
     parser = parser()
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
-    try:
-        if run(args):
-            sys.exit(os.EX_OK)
-    except Exception as e:
-        print("error: ", e)
-        raise Exception("Main evaluation run failed.")
+    # try:
+    if run(args):
+        sys.exit(os.EX_OK)
+    # except Exception as e:
+    #     print("error: ", e)
+    #     raise Exception("Main evaluation run failed.")

--- a/experiments/example_euroc.yaml
+++ b/experiments/example_euroc.yaml
@@ -25,3 +25,13 @@ datasets_to_run:
    initial_frame: 100
    final_frame: 3500
    parallel_run: true
+ - name: V1_03_difficult
+   use_lcd: true
+   plot_vio_and_pgo: true
+   segments: [5]
+   pipelines: ['S']
+   discard_n_start_poses: 10
+   discard_n_end_poses: 10
+   initial_frame: 100
+   final_frame: 3500
+   parallel_run: true


### PR DESCRIPTION
Make `DatasetRunner` a class member of `DatasetEvaluator`.
`DatasetEvaluator` is now the main api for evaluation.

The evaluator first runs each pipeline if needed, and evaluates every run immediately after completing the run. This means evaluation failures can be caught immediately instead of having to wait for all datasets to be run.