### PR TITLE
Fix/data source fast failure

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -1,5 +1,5 @@
 git clone git@github.com:ToniRV/evo-1.git evo
 pip install ./evo --upgrade --no-binary evo
-pip install pyyaml=3.12
+pip install ruamel.yaml
 
 # y virtualenv necesita correr en python2, python3 la lia amb tkinter


### PR DESCRIPTION
Refactored to move the code that generates results and metrics data to a separate function to clean the code a bit.

Fixed the bug causing [this pr](https://github.mit.edu/SPARK/VIO/pull/294) to fail. This was caused by pgo trajectory being synchronized and aligned after `num_poses` for `reduce_to_ids` was selected (incorrectly).